### PR TITLE
Fix type error in sample-multivariate-normal

### DIFF
--- a/multivariate-normal.rkt
+++ b/multivariate-normal.rkt
@@ -70,12 +70,12 @@
   (define L (array->flarray (cholesky covariance)))
 
   (: sample : (Sample [Matrix Flonum]))
-  (define (sample [samples #f])
-    (if samples
-        (for/list: : [Listof [Matrix Flonum]]
+  (define sample
+    (case-lambda:
+      [() (matrix+ mean (matrix* L (base-mvn (square-matrix-size covariance))))]
+      [(samples) (for/list: : [Listof [Matrix Flonum]]
                    ([i (in-range 0 samples)])
-          (matrix+ mean (matrix* L (base-mvn (square-matrix-size covariance)))))
-        (matrix+ mean (matrix* L (base-mvn (square-matrix-size covariance))))))
+          (matrix+ mean (matrix* L (base-mvn (square-matrix-size covariance)))))]))
 
   sample)
 


### PR DESCRIPTION
Racket 7.1 does not accept code as-is.  Modeled this change off of normal-dist.rkt distributed with Racket.