### PR TITLE
update to cholesky: make-matrix no longer accepts 0x0 dimensions

### DIFF
--- a/cholesky.rkt
+++ b/cholesky.rkt
@@ -61,7 +61,7 @@
 
   (for*/fold: : [Matrix Real]
               ([L : [Matrix Real] (build-cholesky-column A
-                                                         (make-matrix 0 0 0)
+                                                         (make-matrix 1 1 0)
                                                          0
                                                          n)])
               ([k : Natural (in-range 1 n)])


### PR DESCRIPTION
Since the 0-size matrix is just a type-filler, it's safe to pass in a 1x1 matrix, though sketchy.
Code-as-is signals a runtime error.